### PR TITLE
Added AssertJ to build.gradle.kts and refactored tests of SingleCharT…

### DIFF
--- a/libs/commons/build.gradle.kts
+++ b/libs/commons/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   testCompile("org.junit.jupiter:junit-jupiter-api:5.3.2")
   testCompile("org.junit.jupiter:junit-jupiter-params:5.3.2")
   testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")
+  testCompile("org.assertj:assertj-core:3.11.1")
 }
 
 

--- a/libs/commons/src/main/kotlin/commons/parse/text/Token.kt
+++ b/libs/commons/src/main/kotlin/commons/parse/text/Token.kt
@@ -23,47 +23,25 @@ open class Token<E: Enum<E>>(open val type: E, startParam: Int, finishParam: Int
   open val finish: Int = finishParam
 
 
-    /**
-     * Gives [CharSequence] representation of this token based on a [source] [CharSequence]
-     */
-    open fun subSequence(source: CharSequence): CharSequence = source.subSequence(start, finish + 1)
+  /**
+   * Gives [CharSequence] representation of this token based on a [source] [CharSequence]
+   */
+  open fun subSequence(source: CharSequence): CharSequence = source.subSequence(start, finish + 1)
 
 
-    /**
-     * Pretty printing of this token based on a [source] [CharSequence]
-     *
-     * @param source is a source [CharSequence] for this token
-     */
-    open fun prettyPrint(source: CharSequence) =
-        println("$type : " + " ".repeat(start) + "'${subSequence(source).toString()}'")
+  /**
+   * Pretty printing of this token based on a [source] [CharSequence]
+   *
+   * @param source is a source [CharSequence] for this token
+   */
+  open fun prettyPrint(source: CharSequence) =
+      println("$type : " + " ".repeat(start) + "'${subSequence(source).toString()}'")
 
 
-    /**
-     * Gives length of the token in characters
-     */
-    open fun length(): Int = finish - start + 1
-
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as Token<*>
-
-    if (type != other.type) return false
-    if (start != other.start) return false
-    if (finish != other.finish) return false
-
-    return true
-  }
-
-
-  override fun hashCode(): Int {
-    var result = type.hashCode()
-    result = 31 * result + start
-    result = 31 * result + finish
-    return result
-  }
+  /**
+   * Gives length of the token in characters
+   */
+  open fun length(): Int = finish - start + 1
 
 
   override fun toString(): String {

--- a/libs/commons/src/test/kotlin/commons/parse/text/SingeCharTokenizerTest.kt
+++ b/libs/commons/src/test/kotlin/commons/parse/text/SingeCharTokenizerTest.kt
@@ -1,6 +1,6 @@
 package com.jvmlab.commons.parse.text
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
@@ -14,31 +14,31 @@ class SingeCharTokenizerTest {
   @Test
   fun `non matching not last`() {
     tokenizer.processChar(' ', 0, false)
-    assertEquals(BuildingStatus.NONE, tokenizer.getBuildingStatus())
+    assertThat(tokenizer.getBuildingStatus()).isEqualTo(BuildingStatus.NONE)
   }
 
   @Test
   fun `non matching last`() {
     tokenizer.processChar(' ', 0, true)
-    assertEquals(BuildingStatus.NONE, tokenizer.getBuildingStatus())
+    assertThat(tokenizer.getBuildingStatus()).isEqualTo(BuildingStatus.NONE)
   }
 
   @Test
   fun `matching not last`() {
     tokenizer.processChar('$', 0, false)
-    assertEquals(BuildingStatus.FINISHED, tokenizer.getBuildingStatus())
+    assertThat(tokenizer.getBuildingStatus()).isEqualTo(BuildingStatus.FINISHED)
 
     val token = tokenizer.buildToken()
-    assertEquals(Token(TokenType.DEFAULT, 0, 0), token)
+    assertThat(token).isEqualToComparingFieldByField(Token(TokenType.DEFAULT, 0, 0))
   }
 
   @Test
   fun `matching last`() {
     tokenizer.processChar('$', 0, true)
-    assertEquals(BuildingStatus.FINISHED, tokenizer.getBuildingStatus())
+    assertThat(tokenizer.getBuildingStatus()).isEqualTo(BuildingStatus.FINISHED)
 
     val token = tokenizer.buildToken()
-    assertEquals(Token(TokenType.DEFAULT, 0, 0), token)
+    assertThat(token).isEqualToComparingFieldByField(Token(TokenType.DEFAULT, 0, 0))
   }
 }
 


### PR DESCRIPTION
…okenizer, closes #23

Token class no longer needs equals() and hashcode() methods as we are using AssertJ assertions